### PR TITLE
fix: do not specify outDir in base config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Then extend in your own config:
 ```json
 {
   "extends": "@zakodium/tsconfig",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "lib"
+  },
   "include": ["src"]
 }
 ```

--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -3,7 +3,6 @@
     "lib": ["ES2023"],
     "types": [],
     "target": "ES2023",
-    "outDir": "lib",
     "module": "NodeNext",
     "rewriteRelativeImportExtensions": true,
     "erasableSyntaxOnly": true,


### PR DESCRIPTION
The directory is relative to the location of the config file that defines it, so it must be in the project config.
